### PR TITLE
Fix asterisk in CSS

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-* {
+:root {
   box-sizing: border-box;
   color: #333;
   display: flex;
@@ -16,10 +16,9 @@ body {
 .user-signup h2,
 .user-login h2 {
   -webkit-text-fill-color: black;
-  -webkit-text-stroke: 1px ;
-  color: papayawhip
+  -webkit-text-stroke: 1px;
+  color: papayawhip;
 }
-
 
 .user-login,
 .user-signup,
@@ -76,4 +75,3 @@ body {
   float: left;
   margin-bottom: 25px;
 }
-


### PR DESCRIPTION
Vite imports CSS with a css-loader in javascript, and the `*` conflicts with that import apparently. The workaround is to use `:root` instead 👍. The other lines in the diff are just whitespace changes that my text editor inserted automatically. 

Fixes https://github.com/thedrewery/koo-koo-drew/issues/13